### PR TITLE
fix: HTTP transport never bound a listener and couldn't handle more than one MCP session

### DIFF
--- a/packages/core/src/universal-mcp-server-http.ts
+++ b/packages/core/src/universal-mcp-server-http.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import 'reflect-metadata';
 import { UniversalBobTheFixerMCPServer } from './universal/universal-mcp-server.js';
 import { getLogger } from './shared/logger/structured-logger.js';
 

--- a/packages/core/src/universal/transport/transport-factory.ts
+++ b/packages/core/src/universal/transport/transport-factory.ts
@@ -9,6 +9,7 @@ export interface HTTPTransportConfig {
   host?: string;
   basePath?: string;
   sessionIdGenerator?: (() => string) | undefined;
+  onsessioninitialized?: (sessionId: string) => void;
 }
 
 export class TransportFactory {
@@ -27,7 +28,8 @@ export class TransportFactory {
         const sessionIdGenerator = config?.sessionIdGenerator ?? (() => randomUUID());
 
         return new StreamableHTTPServerTransport({
-          sessionIdGenerator
+          sessionIdGenerator,
+          onsessioninitialized: config?.onsessioninitialized
         });
       }
 

--- a/packages/core/src/universal/universal-mcp-server.ts
+++ b/packages/core/src/universal/universal-mcp-server.ts
@@ -5,11 +5,16 @@ import {
   InitializeRequestSchema,
   ListToolsRequestSchema,
   CallToolRequestSchema,
-  SetLevelRequestSchema
+  SetLevelRequestSchema,
+  isInitializeRequest
 } from '@modelcontextprotocol/sdk/types.js';
+import { randomUUID } from 'crypto';
 import { TransportFactory, TransportMode, HTTPTransportConfig } from './transport/transport-factory.js';
+import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import dotenv from 'dotenv';
 import path from 'path';
+import express from 'express';
+import type { Server as HttpServer } from 'http';
 import { ProjectManager } from './project-manager.js';
 
 // Security and validation imports
@@ -53,6 +58,7 @@ class UniversalBobTheBuilderMCPServer {
   private readonly lifecycle: ServerLifecycleManager = getLifecycleManager();
   private readonly config: ServerConfig;
   private versionChecker?: VersionChecker;
+  private httpServer?: HttpServer;
 
   constructor(config: ServerConfig = {}) {
     // ============================================================================
@@ -365,12 +371,89 @@ class UniversalBobTheBuilderMCPServer {
 
       // Create transport based on configuration
       const transportMode = this.config.transport!;
-      const transport = transportMode === 'stdio'
-        ? TransportFactory.create('stdio')
-        : TransportFactory.create('http', this.config.httpConfig);
 
+      if (transportMode === 'stdio') {
+        const transport = TransportFactory.create('stdio');
+        await this.server.connect(transport);
+      } else {
+        // StreamableHTTPServerTransport does not open a TCP listener by
+        // itself: it only knows how to handle a single (req, res) pair
+        // handed to it by an HTTP framework, and each transport instance
+        // may only ever complete ONE 'initialize' handshake — reusing the
+        // same transport for a later client (e.g. a second "test connection"
+        // click) fails with "Server already initialized". So we keep a
+        // map of session-id -> transport and mint a fresh transport for
+        // every new initialize request, following the MCP SDK's own
+        // Streamable HTTP example.
+        const port = this.config.httpConfig?.port ?? 3000;
+        const host = this.config.httpConfig?.host ?? '0.0.0.0';
+        const basePath = this.config.httpConfig?.basePath ?? '/mcp/v1/messages';
+        const transports: Record<string, StreamableHTTPServerTransport> = {};
 
-      await this.server.connect(transport);
+        const handleSession = async (req: express.Request, res: express.Response) => {
+          const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+          try {
+            if (sessionId && transports[sessionId]) {
+              await transports[sessionId].handleRequest(req, res, req.body);
+              return;
+            }
+
+            if (!sessionId && req.method === 'POST' && isInitializeRequest(req.body)) {
+              const transport = TransportFactory.create('http', {
+                ...this.config.httpConfig,
+                sessionIdGenerator: () => randomUUID(),
+                onsessioninitialized: (newSessionId: string) => {
+                  transports[newSessionId] = transport;
+                }
+              } as HTTPTransportConfig);
+
+              transport.onclose = () => {
+                const sid = transport.sessionId;
+                if (sid) {
+                  delete transports[sid];
+                }
+              };
+
+              await this.server.connect(transport);
+              await transport.handleRequest(req, res, req.body);
+              return;
+            }
+
+            res.status(400).json({
+              jsonrpc: '2.0',
+              error: { code: -32000, message: 'Bad Request: No valid session ID provided' },
+              id: null
+            });
+          } catch (error) {
+            this.logger.error('Error handling MCP HTTP request', error as Error);
+            if (!res.headersSent) {
+              res.status(500).json({
+                jsonrpc: '2.0',
+                error: { code: -32603, message: 'Internal server error' },
+                id: null
+              });
+            }
+          }
+        };
+
+        const app = express();
+        app.use(express.json());
+
+        app.get('/health', (_req, res) => {
+          res.json({ status: 'ok' });
+        });
+
+        app.post(basePath, handleSession);
+        app.get(basePath, handleSession);
+        app.delete(basePath, handleSession);
+
+        await new Promise<void>((resolve, reject) => {
+          const srv = app.listen(port, host, () => resolve());
+          srv.once('error', reject);
+          this.httpServer = srv;
+        });
+      }
 
 
       // Server is now ready for client communication


### PR DESCRIPTION
## Problem

Running the HTTP transport (`npm run start:mcp:http`) had two bugs that made it unusable behind any real MCP client (found while wiring Bob the Fixer into Inlay Studio via `http://<host>:<port>/mcp/v1/messages`):

1. **Crash on startup**: `universal-mcp-server-http.ts` didn't import `reflect-metadata`, which `tsyringe` requires. The process crashed immediately with:
   ```
   Error: tsyringe requires a reflect polyfill. Please add 'import "reflect-metadata"' to the top of your entry point.
   ```

2. **No listener ever bound**: even after fixing the import, the process logged `✅ Bob the Fixer HTTP server running on http://0.0.0.0:<port>` but nothing was actually listening on that port. `StreamableHTTPServerTransport` from the MCP SDK only knows how to handle a single `(req, res)` pair handed to it by an HTTP framework — it does not open a TCP listener itself. `universal-mcp-server.ts` never wired the transport into an HTTP server/framework.

3. **Only one client session ever worked**: after adding the Express wiring, a single global transport instance was reused for every request. `StreamableHTTPServerTransport` only supports one `initialize` handshake per instance, so any client connecting after the first one (e.g. clicking "Test connection" a second time in an MCP client UI) failed with:
   ```
   Invalid Request: Server already initialized
   ```

## Fix

- Add the missing `reflect-metadata` import to `universal-mcp-server-http.ts`.
- In `UniversalBobTheFixerMCPServer.start()`, actually bind an Express app to the configured `port`/`host` and forward requests to the MCP transport, exposing `/health` and the MCP endpoint (`basePath`, default `/mcp/v1/messages`).
- Implement per-session transport handling: keep a map keyed by `mcp-session-id`, mint a fresh `StreamableHTTPServerTransport` for every new `initialize` request (registered via a new `onsessioninitialized` callback), reuse it for subsequent requests on that session, and clean it up on transport close — following the pattern from the MCP TypeScript SDK's own Streamable HTTP example.
- Extend `HTTPTransportConfig`/`TransportFactory` to pass through `onsessioninitialized`.

## Testing

- `npm run build` passes with no type errors.
- Started the HTTP server locally (`PORT=3010 npm run start:mcp:http`) and confirmed:
  - `GET /health` → `200 {"status":"ok"}`
  - `POST /mcp/v1/messages` with an `initialize` request → valid MCP response with `serverInfo`/`capabilities`.
  - Repeated `initialize` calls (simulating multiple "Test connection" clicks from an MCP client) all succeed instead of failing on the second attempt.
  - Verified end-to-end against a real client (Inlay Studio) registering this server as an HTTP MCP server — connection test now reports success with the expected tool count.